### PR TITLE
Remove extra line of whitespace at end of results

### DIFF
--- a/src/components/Gameboard.vue
+++ b/src/components/Gameboard.vue
@@ -58,7 +58,7 @@ function getResults() {
     lose ? "X" : resultsArray.length / 5
   }/6
 
-${results}`;
+${results}`.trim();
 }
 
 function shakeTiles(tiles: HTMLDivElement[]) {


### PR DESCRIPTION
- Remove extra line of whitespace at end of results.

- Close #8.